### PR TITLE
feat: tool annotations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ class PocketBaseServer {
             },
             required: ['name', 'fields'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'update_collection',
           description: 'Update an existing collection in PocketBase (admin only)',
@@ -215,7 +215,7 @@ class PocketBaseServer {
             },
             required: ['collectionIdOrName'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'create_record',
           description: 'Create a new record in a collection',
@@ -238,7 +238,7 @@ class PocketBaseServer {
             },
             required: ['collection', 'data'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'list_records',
           description: 'List records from a collection with optional filters',
@@ -273,7 +273,7 @@ class PocketBaseServer {
             },
             required: ['collection'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'update_record',
           description: 'Update an existing record',
@@ -300,7 +300,7 @@ class PocketBaseServer {
             },
             required: ['collection', 'id', 'data'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'delete_record',
           description: 'Delete a record',
@@ -323,7 +323,7 @@ class PocketBaseServer {
             },
             required: ['collection', 'id'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'list_auth_methods',
           description: 'List all available authentication methods',
@@ -342,7 +342,7 @@ class PocketBaseServer {
               }
             }
           }
-        } as ToolWithAnnotations,
+        },
         {
           name: 'authenticate_user',
           description: 'Authenticate a user with email and password',
@@ -375,7 +375,7 @@ class PocketBaseServer {
             },
             required: ['email', 'password'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'authenticate_with_oauth2',
           description: 'Authenticate a user with OAuth2',
@@ -411,7 +411,7 @@ class PocketBaseServer {
             },
             required: ['provider', 'code', 'codeVerifier', 'redirectUrl'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'authenticate_with_otp',
           description: 'Authenticate a user with one-time password',
@@ -435,7 +435,7 @@ class PocketBaseServer {
             },
             required: ['email'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'auth_refresh',
           description: 'Refresh authentication token',
@@ -454,7 +454,7 @@ class PocketBaseServer {
               }
             }
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'request_verification',
           description: 'Request email verification',
@@ -478,7 +478,7 @@ class PocketBaseServer {
             },
             required: ['email'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'confirm_verification',
           description: 'Confirm email verification with token',
@@ -502,7 +502,7 @@ class PocketBaseServer {
             },
             required: ['token'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'request_password_reset',
           description: 'Request password reset',
@@ -526,7 +526,7 @@ class PocketBaseServer {
             },
             required: ['email'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'confirm_password_reset',
           description: 'Confirm password reset with token',
@@ -558,7 +558,7 @@ class PocketBaseServer {
             },
             required: ['token', 'password', 'passwordConfirm'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'request_email_change',
           description: 'Request email change',
@@ -582,7 +582,7 @@ class PocketBaseServer {
             },
             required: ['newEmail'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'confirm_email_change',
           description: 'Confirm email change with token',
@@ -610,7 +610,7 @@ class PocketBaseServer {
             },
             required: ['token', 'password'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'impersonate_user',
           description: 'Impersonate another user (admin only)',
@@ -639,7 +639,7 @@ class PocketBaseServer {
             },
             required: ['id'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'create_user',
           description: 'Create a new user account',
@@ -675,7 +675,7 @@ class PocketBaseServer {
             },
             required: ['email', 'password', 'passwordConfirm'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'get_collection',
           description: 'Get details for a collection',
@@ -698,7 +698,7 @@ class PocketBaseServer {
             },
             required: ['collectionIdOrName'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'backup_database',
           description: 'Create a backup of the PocketBase database',
@@ -716,7 +716,7 @@ class PocketBaseServer {
               },
             },
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'import_data',
           description: 'Import data into a collection',
@@ -747,7 +747,7 @@ class PocketBaseServer {
             },
             required: ['collection', 'data'],
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'list_collections',
           description: 'List all collections in PocketBase',
@@ -769,7 +769,7 @@ class PocketBaseServer {
               },
             },
           },
-        } as ToolWithAnnotations,
+        },
         {
           name: 'delete_collection',
           description: 'Delete a collection from PocketBase (admin only)',
@@ -788,8 +788,8 @@ class PocketBaseServer {
             },
             required: ['collectionIdOrName'],
           },
-        } as ToolWithAnnotations,
-      ],
+        },
+      ] as ToolWithAnnotations[],
     }));
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,18 @@ import {
   ErrorCode,
   ListToolsRequestSchema,
   McpError,
+  Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import PocketBase from 'pocketbase';
 
-
+type ToolWithAnnotations = Tool & {
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
+};
 
 class PocketBaseServer {
   private server: Server;
@@ -50,6 +58,11 @@ class PocketBaseServer {
         {
           name: 'create_collection',
           description: 'Create a new collection in PocketBase note never use created and updated because these are already created',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -120,10 +133,15 @@ class PocketBaseServer {
             },
             required: ['name', 'fields'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'update_collection',
           description: 'Update an existing collection in PocketBase (admin only)',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -197,10 +215,15 @@ class PocketBaseServer {
             },
             required: ['collectionIdOrName'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'create_record',
           description: 'Create a new record in a collection',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -215,10 +238,15 @@ class PocketBaseServer {
             },
             required: ['collection', 'data'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'list_records',
           description: 'List records from a collection with optional filters',
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -245,10 +273,15 @@ class PocketBaseServer {
             },
             required: ['collection'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'update_record',
           description: 'Update an existing record',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -267,10 +300,15 @@ class PocketBaseServer {
             },
             required: ['collection', 'id', 'data'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'delete_record',
           description: 'Delete a record',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -285,10 +323,15 @@ class PocketBaseServer {
             },
             required: ['collection', 'id'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'list_auth_methods',
           description: 'List all available authentication methods',
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -299,10 +342,15 @@ class PocketBaseServer {
               }
             }
           }
-        },
+        } as ToolWithAnnotations,
         {
           name: 'authenticate_user',
           description: 'Authenticate a user with email and password',
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -327,10 +375,15 @@ class PocketBaseServer {
             },
             required: ['email', 'password'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'authenticate_with_oauth2',
           description: 'Authenticate a user with OAuth2',
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -358,10 +411,15 @@ class PocketBaseServer {
             },
             required: ['provider', 'code', 'codeVerifier', 'redirectUrl'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'authenticate_with_otp',
           description: 'Authenticate a user with one-time password',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -377,10 +435,15 @@ class PocketBaseServer {
             },
             required: ['email'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'auth_refresh',
           description: 'Refresh authentication token',
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -391,10 +454,15 @@ class PocketBaseServer {
               }
             }
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'request_verification',
           description: 'Request email verification',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -410,10 +478,15 @@ class PocketBaseServer {
             },
             required: ['email'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'confirm_verification',
           description: 'Confirm email verification with token',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -429,10 +502,15 @@ class PocketBaseServer {
             },
             required: ['token'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'request_password_reset',
           description: 'Request password reset',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -448,10 +526,15 @@ class PocketBaseServer {
             },
             required: ['email'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'confirm_password_reset',
           description: 'Confirm password reset with token',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -475,10 +558,15 @@ class PocketBaseServer {
             },
             required: ['token', 'password', 'passwordConfirm'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'request_email_change',
           description: 'Request email change',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -494,10 +582,15 @@ class PocketBaseServer {
             },
             required: ['newEmail'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'confirm_email_change',
           description: 'Confirm email change with token',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -517,10 +610,15 @@ class PocketBaseServer {
             },
             required: ['token', 'password'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'impersonate_user',
           description: 'Impersonate another user (admin only)',
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -541,10 +639,15 @@ class PocketBaseServer {
             },
             required: ['id'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'create_user',
           description: 'Create a new user account',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -572,10 +675,15 @@ class PocketBaseServer {
             },
             required: ['email', 'password', 'passwordConfirm'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'get_collection',
           description: 'Get details for a collection',
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -590,10 +698,15 @@ class PocketBaseServer {
             },
             required: ['collectionIdOrName'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'backup_database',
           description: 'Create a backup of the PocketBase database',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -603,10 +716,15 @@ class PocketBaseServer {
               },
             },
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'import_data',
           description: 'Import data into a collection',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -629,10 +747,15 @@ class PocketBaseServer {
             },
             required: ['collection', 'data'],
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'list_collections',
           description: 'List all collections in PocketBase',
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -646,10 +769,15 @@ class PocketBaseServer {
               },
             },
           },
-        },
+        } as ToolWithAnnotations,
         {
           name: 'delete_collection',
           description: 'Delete a collection from PocketBase (admin only)',
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+          },
           inputSchema: {
             type: 'object',
             properties: {
@@ -660,7 +788,7 @@ class PocketBaseServer {
             },
             required: ['collectionIdOrName'],
           },
-        },
+        } as ToolWithAnnotations,
       ],
     }));
 


### PR DESCRIPTION
Thought it might be useful to annotate the tools in this MCP server as read/write operations, as it looks nice in Claude desktop when I'm looking at what tools are available and [they can give agents helpful context](https://blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/). Since the MCP deals with a lot of write operations I think this could be useful. The latest MCP SDK version has this built in, but for minimal code change with the version used in this codebase I've created a new `ToolWithAnnotations` type that extends `Tool`, and labeled existing tools with the appropriate hints.

What it looks like in Claude Desktop:
<img width="911" height="612" alt="Screenshot 2026-07-04 at 7 46 38 PM" src="https://github.com/user-attachments/assets/b0c9dcfb-2923-4454-ab6c-5b995ef81103" />
